### PR TITLE
Minor refactors

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,8 +65,7 @@ def create_metadata(description: str, token_name: str, edition: int, final_layer
             #{'trait_type': '', 'value': ''},
             #{'trait_type': '', 'value': ''},
             #{'trait_type': '', 'value': ''}
-        ],
-        'compiler': 'zc engine'
+        ]
     }
 
     for layer in final_layers:
@@ -95,7 +94,7 @@ def create_image(token_name: str, edition: int, final_layers: list):
         img = Image.open(filepath)
         background_layer.paste(img, img)
 
-    background_layer.save(f'build/images/{token_name} #{edition}.png')
+    background_layer.save(f'build/images/{token_name}-{edition}.png')
 
 
 def main():

--- a/main.py
+++ b/main.py
@@ -13,17 +13,13 @@ def make_dirs():
     """Creates the directories to store final images and later on, their corresponding json data. If
     the folders already exist, print to confirm and continue with the program.
     """
-    # TODO: Decompose this logic from the try/except/else statement; unnecessary - hides info
-    try:
-        # TODO: Add conditional check for each dir, then create
-        os.mkdir('build')
-        os.mkdir('build/images')
-        os.mkdir('build/json')
-    except:
-        print('Build folders already exist. No more will be created')
-    else:
-        print('Build folders successfully created.')
-
+    print('Creating build directories')
+    build_dirs = ['build', 'build/images', 'build/json']
+    for _dir in build_dirs:
+        if not os.path.isdir(_dir):
+            print(f'Directory does not yet exist; creating {_dir}')
+            os.mkdir(_dir)
+    print('Build directories created')
 
 def join_layers(assets: str) -> list:
     """Loops through each layer folder and chooses

--- a/main.py
+++ b/main.py
@@ -15,10 +15,12 @@ def make_dirs():
     """
     print('Creating build directories')
     build_dirs = ['build', 'build/images', 'build/json']
+
     for _dir in build_dirs:
         if not os.path.isdir(_dir):
             print(f'Directory does not yet exist; creating {_dir}')
             os.mkdir(_dir)
+
     print('Build directories created')
 
 def join_layers(assets: str) -> list:
@@ -77,7 +79,7 @@ def create_metadata(description: str, token_name: str, edition: int, final_layer
 
         metadata['attributes'].append(intemediary_dict)
 
-    with open(f'build/json/{edition}.json', 'w') as outfile:
+    with open(f'build/json/{edition}.json', 'w', encoding='utf-8') as outfile:
         json.dump(metadata, outfile, indent=2)
 
 

--- a/updatebaseuri.py
+++ b/updatebaseuri.py
@@ -1,3 +1,5 @@
+""" Retroactively replaces the JSON 'baseURI' file after it is known """
+
 import json
 
 def update_base_uri():
@@ -16,7 +18,7 @@ def update_base_uri():
 
         # TODO: These probably don't need to be two file operations separately
         # Opens json file
-        with open(json_path, 'r') as infile:
+        with open(json_path, 'r', encoding='utf-8') as infile:
 
             # Load the opened json file into a Python dict
             data = json.load(infile)
@@ -25,7 +27,7 @@ def update_base_uri():
             data['image'] = data['image'].replace('baseURI', new_uri)
 
         # Opens the original json file and writes the new data
-        with open(json_path, 'w') as outfile:
+        with open(json_path, 'w', encoding='utf-8') as outfile:
             json.dump(data, outfile, indent=2)
 
         edition += 1


### PR DESCRIPTION
This PR does the following:
- Decomposes the try/except/else statement in the build directories creation process so that specific errors can surface.
- Remove spaces and hashtag/octothorpe/pound from filepaths to avoid possible processing or readability issues around these.
- Add `encoding='utf-8'` to the file operations context managers to appease the linting gods.